### PR TITLE
Change the way to get PID so that dumping does not fail under certain conditions

### DIFF
--- a/Il2CppMemoryDumper.sh
+++ b/Il2CppMemoryDumper.sh
@@ -23,11 +23,10 @@ echo "- Output directory: $out"
 
 mkdir -p "$out"
 
-user=$(am get-current-user)
-pid=$(ps -ef | grep -w $package | grep u$user | awk '{print $2}')
+pid=$(pgrep -fox "$package")
 
 if [[ $pid == "" ]]; then
-	echo "! Target package of current user ($user) not found, is process running?"
+	echo "! The process for the target package was not found, is process running?"
 	exit
 fi
 

--- a/Il2CppMemoryDumper.sh
+++ b/Il2CppMemoryDumper.sh
@@ -24,7 +24,7 @@ echo "- Output directory: $out"
 mkdir -p "$out"
 
 user=$(am get-current-user)
-pid=$(ps -ef | grep $package | grep u$user | awk '{print $2}')
+pid=$(ps -ef | grep -w $package | grep u$user | awk '{print $2}')
 
 if [[ $pid == "" ]]; then
 	echo "! Target package of current user ($user) not found, is process running?"


### PR DESCRIPTION
With the current code, if the game has subprocesses, two PIDs will be retrieved, and it won't be able to dump correctly

<img width="838" height="563" alt="image" src="https://github.com/user-attachments/assets/7d3dc2da-65e9-425f-94b3-f713176cf32a" />

Using pgrep with the -fox option ensures that exactly one PID is retrieved